### PR TITLE
Add a CI pipeline for the Unreal Engine project.

### DIFF
--- a/.github/scripts/build.py
+++ b/.github/scripts/build.py
@@ -1,0 +1,18 @@
+from ue4helpers import ProjectBuild
+import os
+
+# Get the project root directory from an environment variable
+project_root = os.environ.get("GITHUB_WORKSPACE")
+if not project_root:
+    raise Exception("GITHUB_WORKSPACE environment variable not set")
+
+# Create a ProjectBuild instance
+builder = ProjectBuild(project_root)
+
+# Build the project for Win64, Linux, and Mac
+# You may want to customize these platforms based on your needs
+builder.build("Win64", "Development")
+builder.build("Linux", "Development")
+builder.build("Mac", "Development")
+
+print("Project build successful!")

--- a/.github/scripts/package.py
+++ b/.github/scripts/package.py
@@ -1,0 +1,33 @@
+from ue4helpers import ProjectPackager, VersionHelpers
+import os
+
+# Get the project root directory from an environment variable
+project_root = os.environ.get("GITHUB_WORKSPACE")
+if not project_root:
+    raise Exception("GITHUB_WORKSPACE environment variable not set")
+
+# Create a ProjectPackager instance
+packager = ProjectPackager(
+    root=project_root,
+    version=VersionHelpers.from_git_commit(),
+    archive='{name}-{version}-{platform}',
+    strip_debug=False,
+    strip_manifests=False
+)
+
+# Clean any previous build artifacts
+packager.clean()
+
+# Package the project for Win64, Linux, and Mac
+# You may want to customize these platforms based on your needs
+packager.package_platform("Win64", "Development")
+packager.package_platform("Linux", "Development")
+packager.package_platform("Mac", "Development")
+
+# Compress the packaged distributions
+packager.archive_platform("Win64")
+packager.archive_platform("Linux")
+packager.archive_platform("Mac")
+
+
+print("Project packaged successfully!")

--- a/.github/scripts/run_tests.py
+++ b/.github/scripts/run_tests.py
@@ -1,0 +1,16 @@
+from ue4helpers import EditorTest
+import os
+
+# Get the project root directory from an environment variable
+project_root = os.environ.get("GITHUB_WORKSPACE")
+if not project_root:
+    raise Exception("GITHUB_WORKSPACE environment variable not set")
+
+# Create an EditorTest instance
+tester = EditorTest(project_root)
+
+# Run the tests
+# You may want to customize the test flags based on your needs
+tester.run_tests(test_flags="-ExecCmds="Automation RunTests Project.Functional Tests" -testexit="Automation Test Queue Empty" -ReportExportPath="../Saved/TestReport"")
+
+print("Tests run successfully!")

--- a/.github/workflows/mirror-ue4-image.yml
+++ b/.github/workflows/mirror-ue4-image.yml
@@ -1,0 +1,40 @@
+name: Mirror UE4 Docker Image
+
+on:
+  workflow_dispatch: # Allows manual triggering
+
+jobs:
+  mirror-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # Permission to push to GHCR
+
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Define image names
+        id: image_names
+        run: |
+          SOURCE_IMAGE="adamrehn/ue4-full:4.27.2-cudagl11.2.2-ubuntu18.04"
+          TARGET_IMAGE="ghcr.io/${{ github.repository_owner }}/${{ github.event.repository.name }}/ue4-full:4.27.2-cudagl11.2.2-ubuntu18.04"
+          # Sanitize repository name (convert to lowercase)
+          TARGET_IMAGE_LOWER=$(echo "$TARGET_IMAGE" | tr '[:upper:]' '[:lower:]')
+          echo "SOURCE_IMAGE_NAME=$SOURCE_IMAGE" >> $GITHUB_OUTPUT
+          echo "TARGET_IMAGE_NAME=$TARGET_IMAGE_LOWER" >> $GITHUB_OUTPUT
+
+      - name: Pull, Re-tag, and Push Docker Image
+        run: |
+          docker pull ${{ steps.image_names.outputs.SOURCE_IMAGE_NAME }}
+          docker tag ${{ steps.image_names.outputs.SOURCE_IMAGE_NAME }} ${{ steps.image_names.outputs.TARGET_IMAGE_NAME }}
+          docker push ${{ steps.image_names.outputs.TARGET_IMAGE_NAME }}
+        env:
+          DOCKER_CLI_AGGREGATE: "1" # Enables progress output for pull/push
+
+      - name: Echo target image name
+        run: echo "Successfully mirrored image to ${{ steps.image_names.outputs.TARGET_IMAGE_NAME }}"

--- a/.github/workflows/ue4-ci.yml
+++ b/.github/workflows/ue4-ci.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Required for ue4-ci-helpers to determine the version string
+          clean: false # Required for ue4-ci-helpers
 
       - name: Install ue4-ci-helpers
         run: pip install ue4-ci-helpers
@@ -30,7 +31,7 @@ jobs:
         run: python .github/scripts/package.py
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: packaged-project
           path: |

--- a/.github/workflows/ue4-ci.yml
+++ b/.github/workflows/ue4-ci.yml
@@ -1,0 +1,40 @@
+name: UE4 CI
+
+on:
+  push:
+    branches: [ "trunk" ]
+  pull_request:
+    branches: [ "trunk" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: adamrehn/ue4-full:4.27.2-cudagl11.2.2-ubuntu18.04 # You might need to adjust the UE version and tags based on your project
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required for ue4-ci-helpers to determine the version string
+
+      - name: Install ue4-ci-helpers
+        run: pip install ue4-ci-helpers
+
+      - name: Build project
+        run: python .github/scripts/build.py
+
+      - name: Run tests
+        run: python .github/scripts/run_tests.py
+
+      - name: Package project
+        run: python .github/scripts/package.py
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: packaged-project
+          path: |
+            Build/Win64/
+            Build/Linux/
+            Build/Mac/
+          if-no-files-found: error # Fail the workflow if no files are found

--- a/.github/workflows/ue4-ci.yml
+++ b/.github/workflows/ue4-ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: adamrehn/ue4-full:4.27.2-cudagl11.2.2-ubuntu18.04 # You might need to adjust the UE version and tags based on your project
+      image: ghcr.io/${{ github.repository_owner,, }}/${{ github.event.repository.name,, }}/ue4-full:4.27.2-cudagl11.2.2-ubuntu18.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This pipeline uses ue4-ci-helpers to build, test, and package the project for Windows, Linux, and Mac. The packaged project is then uploaded as a build artifact.

The pipeline is triggered on push and pull_request events to the trunk branch.