### PR TITLE
feat: Implement prototype GUI for voice command simulation

### DIFF
--- a/Config/DefaultInput.ini
+++ b/Config/DefaultInput.ini
@@ -1,0 +1,2 @@
+[/Script/Engine.InputSettings]
++ActionMappings=(ActionName="LeftMouseClick",bShift=False,bCtrl=False,bAlt=False,bCmd=False,Key=LeftMouseButton)

--- a/Source/RaidingGuildManager/Private/Characters/RaiderCharacter.cpp
+++ b/Source/RaidingGuildManager/Private/Characters/RaiderCharacter.cpp
@@ -9,10 +9,19 @@
 #include "AI/UtilityAI/UtilityAIAction.h" // Required for UUtilityAIAction in Tick
 #include "AI/UtilityAI/AIAction_Log.h"     // Added for test action
 #include "AI/UtilityAI/AIAction_Idle.h"    // Added for test action
+#include "Components/SkeletalMeshComponent.h" // Required for GetMesh()
+#include "Materials/MaterialInterface.h" // Required for UMaterialInterface
+#include "TimerManager.h" // Required for FTimerManager and SetTimer
+#include "AI/UtilityAI/UtilityAIComponent.h" // Ensure UUtilityAIComponent is fully included for its members
 
 
 ARaiderCharacter::ARaiderCharacter()
 {
+	bIsSelected = false; // Default to not selected
+	OriginalMaterial = nullptr;
+	SelectedMaterial = nullptr; // User should set this in Blueprint or C++
+	CurrentDirective = ETemporaryDirective::None; // Initialize directive
+
 	UtilityAIComponent = CreateDefaultSubobject<UUtilityAIComponent>(TEXT("UtilityAIComponent"));
 	if (UtilityAIComponent)
 	{
@@ -36,6 +45,37 @@ ARaiderCharacter::ARaiderCharacter()
 	// Set the AI Controller class
 	AIControllerClass = ARaiderAIController::StaticClass();
 }
+
+void ARaiderCharacter::BeginPlay()
+{
+	Super::BeginPlay();
+
+	// Store the original material
+	if (GetMesh() && GetMesh()->GetMaterial(0))
+	{
+		OriginalMaterial = GetMesh()->GetMaterial(0);
+	}
+	else
+	{
+		UE_LOG(LogTemp, Warning, TEXT("ARaiderCharacter %s: Could not get original material from mesh."), *GetName());
+	}
+
+	// For demonstration, let's try to load a known engine material if SelectedMaterial is not set.
+	// This is a fallback and ideally SelectedMaterial should be set in the editor.
+	if (!SelectedMaterial)
+	{
+		SelectedMaterial = LoadObject<UMaterialInterface>(nullptr, TEXT("/Engine/EngineMaterials/WidgetVertexColorMaterial.WidgetVertexColorMaterial")); // Example material
+		if (SelectedMaterial)
+		{
+			UE_LOG(LogTemp, Log, TEXT("ARaiderCharacter %s: Using fallback SelectedMaterial: %s"), *GetName(), *SelectedMaterial->GetName());
+		}
+		else
+		{
+			UE_LOG(LogTemp, Warning, TEXT("ARaiderCharacter %s: Fallback SelectedMaterial could not be loaded. Selection might not be visible."), *GetName());
+		}
+	}
+}
+
 
 // Example of overriding InitializeAttributes (Uncomment and implement if needed)
 // void ARaiderCharacter::InitializeAttributes()
@@ -67,6 +107,27 @@ void ARaiderCharacter::Tick(float DeltaTime)
 {
 	Super::Tick(DeltaTime);
 
+	// Handle selection material swapping
+	if (GetMesh())
+	{
+		UMaterialInterface* CurrentMaterial = GetMesh()->GetMaterial(0);
+		if (bIsSelected)
+		{
+			if (SelectedMaterial && CurrentMaterial != SelectedMaterial)
+			{
+				GetMesh()->SetMaterial(0, SelectedMaterial);
+			}
+		}
+		else
+		{
+			if (OriginalMaterial && CurrentMaterial != OriginalMaterial)
+			{
+				GetMesh()->SetMaterial(0, OriginalMaterial);
+			}
+		}
+	}
+
+
 	// Basic check to see if we have a controller and the component
 	AController* MyController = GetController();
 	if (MyController && UtilityAIComponent)
@@ -79,4 +140,77 @@ void ARaiderCharacter::Tick(float DeltaTime)
 			SelectedAction->Execute(MyController, this);
 		}
 	}
+}
+
+void ARaiderCharacter::SetSelected(bool bNewSelectedState)
+{
+	bIsSelected = bNewSelectedState;
+}
+
+void ARaiderCharacter::InjectDirective(ETemporaryDirective NewDirective)
+{
+	CurrentDirective = NewDirective;
+	GetWorldTimerManager().ClearTimer(ClearDirectiveTimerHandle); // Clear any existing timer
+
+	UE_LOG(LogTemp, Log, TEXT("ARaiderCharacter %s: Injecting directive: %s"), *GetName(), *UEnum::GetValueAsString(NewDirective));
+
+	if (UtilityAIComponent)
+	{
+		// --- AI Prioritization Logic Placeholder ---
+		// This is where you would integrate with UUtilityAIComponent to force/influence a decision.
+		// Since UUtilityAIComponent doesn't have a ForceDecision method yet, we log a placeholder.
+		// A real implementation might involve:
+		// 1. Adding a method like `ForceAction(FName ActionName, float Duration)` to UUtilityAIComponent.
+		// 2. Or, adding properties to UUtilityAIComponent that considerations can check (e.g. `CurrentForcedDirective`).
+		// 3. Or, directly manipulating scores of certain actions temporarily.
+
+		FName ActionToForce = NAME_None;
+		if (NewDirective == ETemporaryDirective::Taunt)
+		{
+			ActionToForce = TEXT("Taunt"); // Assuming an action named "Taunt" exists in AvailableActions
+		}
+		else if (NewDirective == ETemporaryDirective::Attack)
+		{
+			ActionToForce = TEXT("Attack"); // Assuming an action named "Attack" exists in AvailableActions
+		}
+
+		if (ActionToForce != NAME_None)
+		{
+			UE_LOG(LogTemp, Warning, TEXT("ARaiderCharacter %s: Placeholder - Would force AI action '%s' if UUtilityAIComponent supported it."), *GetName(), *ActionToForce.ToString());
+			// Example of what could be: UtilityAIComponent->ForceDecision(ActionToForce, 5.0f);
+		}
+		else if (NewDirective != ETemporaryDirective::None)
+		{
+			UE_LOG(LogTemp, Warning, TEXT("ARaiderCharacter %s: Unknown directive %s. No AI action forced."), *GetName(), *UEnum::GetValueAsString(NewDirective));
+		}
+		// --- End AI Prioritization Logic Placeholder ---
+	}
+	else
+	{
+		UE_LOG(LogTemp, Error, TEXT("ARaiderCharacter %s: UtilityAIComponent is null. Cannot inject directive."), *GetName());
+	}
+
+	if (NewDirective != ETemporaryDirective::None)
+	{
+		// Set a timer to clear the directive after 5 seconds
+		GetWorldTimerManager().SetTimer(ClearDirectiveTimerHandle, this, &ARaiderCharacter::ClearDirective, 5.0f, false);
+	}
+}
+
+void ARaiderCharacter::ClearDirective()
+{
+	UE_LOG(LogTemp, Log, TEXT("ARaiderCharacter %s: Clearing directive. Previous: %s"), *GetName(), *UEnum::GetValueAsString(CurrentDirective));
+	CurrentDirective = ETemporaryDirective::None;
+
+	if (UtilityAIComponent)
+	{
+		// --- AI Prioritization Clearing Logic Placeholder ---
+		// If a ForceDecision or override was applied, this is where you'd clear it.
+		// Example: UtilityAIComponent->ClearForcedDecision();
+		UE_LOG(LogTemp, Warning, TEXT("ARaiderCharacter %s: Placeholder - Would clear forced AI action if UUtilityAIComponent supported it."), *GetName());
+		// --- End AI Prioritization Clearing Logic Placeholder ---
+	}
+
+	// Timer handle is automatically cleared by TimerManager when it executes a non-looping timer.
+	// ClearDirectiveTimerHandle.Invalidate(); // Not strictly necessary for non-looping, but good for clarity if re-used.
 }

--- a/Source/RaidingGuildManager/Private/GameModes/RaidArenaGameMode.cpp
+++ b/Source/RaidingGuildManager/Private/GameModes/RaidArenaGameMode.cpp
@@ -7,6 +7,7 @@
 #include "Roster/RosterDataTypes.h" // For FRaiderInfoUIData
 #include "Planning/RaidPlanData.h" // For URaidPlanData
 #include "AI/RaiderAIController.h" // For ARaiderAIController cast
+#include "RGMPlayerController.h" // Added for the new Player Controller
 #include "Engine/World.h"
 #include "GameFramework/PlayerStart.h" // If you were to use PlayerStarts for spawning
 #include "Kismet/GameplayStatics.h"   // For UGameplayStatics::GetAllActorsOfClass (alternative spawn point finding)
@@ -16,7 +17,7 @@ ARaidArenaGameMode::ARaidArenaGameMode()
 {
 	// Set default pawn class to null, as we are spawning characters manually.
 	DefaultPawnClass = nullptr;
-	// PlayerControllerClass = AYourPlayerController::StaticClass(); // Set if you have a custom one
+	PlayerControllerClass = ARGMPlayerController::StaticClass(); // Set to use the new RGMPlayerController
 	// HUDClass = AYourHUD::StaticClass(); // Set if you have a custom HUD for this mode
 }
 

--- a/Source/RaidingGuildManager/Private/RGMPlayerController.cpp
+++ b/Source/RaidingGuildManager/Private/RGMPlayerController.cpp
@@ -1,0 +1,203 @@
+#include "RGMPlayerController.h"
+#include "Engine/World.h"
+#include "GameFramework/Actor.h"
+#include "Characters/RaiderCharacter.h" // Required for ARaiderCharacter
+#include "DrawDebugHelpers.h" // Required for DrawDebugLine
+#include "EngineUtils.h" // Required for TActorIterator
+#include "Blueprint/UserWidget.h" // Required for UUserWidget
+#include "UObject/ConstructorHelpers.h" // Required for FClassFinder
+#include "UI/RaiderCommandsWidget.h" // Required for URaiderCommandsWidget
+#include "RaidViewCameraActor.h" // Required for ARaidViewCameraActor
+
+ARGMPlayerController::ARGMPlayerController()
+{
+	bShowMouseCursor = true;
+	bEnableClickEvents = true;
+	SelectedRaider = nullptr; // Initialize SelectedRaider
+	RaiderCommandsWidgetInstance = nullptr; // Initialize widget instance
+
+	// Attempt to find the RaiderCommandsWidget Blueprint class
+	// This path assumes the Blueprint UMG asset WBP_RaiderCommands is created in Content/UI/
+	static ConstructorHelpers::FClassFinder<URaiderCommandsWidget> RaiderCommandsWidgetBPClass(TEXT("/Game/UI/WBP_RaiderCommands"));
+	if (RaiderCommandsWidgetBPClass.Class != nullptr)
+	{
+		RaiderCommandsWidgetClass = RaiderCommandsWidgetBPClass.Class;
+		UE_LOG(LogTemp, Log, TEXT("Successfully found WBP_RaiderCommands class at %s"), *RaiderCommandsWidgetBPClass.GetPathName());
+	}
+	else
+	{
+		RaiderCommandsWidgetClass = nullptr;
+		UE_LOG(LogTemp, Warning, TEXT("Could not find WBP_RaiderCommands class. Ensure it exists at /Game/UI/WBP_RaiderCommands"));
+	}
+}
+
+void ARGMPlayerController::BeginPlay()
+{
+	Super::BeginPlay();
+
+	if (RaiderCommandsWidgetClass)
+	{
+		RaiderCommandsWidgetInstance = CreateWidget<URaiderCommandsWidget>(this, RaiderCommandsWidgetClass);
+		if (RaiderCommandsWidgetInstance)
+		{
+			RaiderCommandsWidgetInstance->AddToViewport();
+			RaiderCommandsWidgetInstance->SetVisibility(ESlateVisibility::Hidden); // Initially hidden
+			UE_LOG(LogTemp, Log, TEXT("RaiderCommandsWidgetInstance created and added to viewport, initially hidden."));
+		}
+		else
+		{
+			UE_LOG(LogTemp, Error, TEXT("Failed to create RaiderCommandsWidgetInstance."));
+		}
+	}
+	else
+	{
+		UE_LOG(LogTemp, Warning, TEXT("RaiderCommandsWidgetClass is null. Cannot create RaiderCommandsWidgetInstance."));
+	}
+
+	// Spawn and set the Raid View Camera
+	UWorld* World = GetWorld();
+	if (World)
+	{
+		FActorSpawnParameters SpawnParams;
+		SpawnParams.Owner = this;
+		// Spawn location and rotation can be adjusted if needed, but camera itself has its view settings.
+		// Spawning at ZeroVector, ZeroRotator means the camera actor itself is at origin,
+		// its internal CameraComponent's relative transform provides the actual view.
+		ARaidViewCameraActor* MyRaidCamera = World->SpawnActor<ARaidViewCameraActor>(ARaidViewCameraActor::StaticClass(), FVector::ZeroVector, FRotator::ZeroRotator, SpawnParams);
+
+		if (MyRaidCamera)
+		{
+			SetViewTarget(MyRaidCamera);
+			UE_LOG(LogTemp, Log, TEXT("ARGMPlayerController: Successfully spawned ARaidViewCameraActor and set as view target."));
+		}
+		else
+		{
+			UE_LOG(LogTemp, Error, TEXT("ARGMPlayerController: Failed to spawn ARaidViewCameraActor."));
+		}
+	}
+	else
+	{
+		UE_LOG(LogTemp, Error, TEXT("ARGMPlayerController: GetWorld() returned null in BeginPlay. Cannot spawn camera."));
+	}
+}
+
+void ARGMPlayerController::SetupInputComponent()
+{
+	Super::SetupInputComponent();
+
+	if (InputComponent)
+	{
+		InputComponent->BindAction("LeftMouseClick", IE_Pressed, this, &ARGMPlayerController::OnLeftMouseClick);
+	}
+}
+
+void ARGMPlayerController::OnLeftMouseClick()
+{
+	FVector MouseLocation, MouseDirection;
+	if (DeprojectMousePositionToWorld(MouseLocation, MouseDirection))
+	{
+		FVector TraceEnd = MouseLocation + (MouseDirection * 10000.0f); // 10000 is the trace distance
+
+		FHitResult HitResult;
+		FCollisionQueryParams CollisionParams;
+		CollisionParams.AddIgnoredActor(this); // Ignore player controller itself
+
+		// Perform the line trace
+		bool bHit = GetWorld()->LineTraceSingleByChannel(
+			HitResult,
+			MouseLocation,
+			TraceEnd,
+			ECC_Visibility, // Trace against the Visibility channel
+			CollisionParams
+		);
+
+		// Optional: Draw debug line to visualize the trace
+		DrawDebugLine(
+			GetWorld(),
+			MouseLocation,
+			TraceEnd,
+			FColor::Red,
+			false, 5.0f, 0,
+			1.0f
+		);
+
+		if (bHit)
+		{
+			AActor* HitActor = HitResult.GetActor();
+			if (HitActor)
+			{
+				ARaiderCharacter* ClickedRaider = Cast<ARaiderCharacter>(HitActor);
+
+				// Deselect all raiders first
+				for (TActorIterator<ARaiderCharacter> It(GetWorld()); It; ++It)
+				{
+					ARaiderCharacter* Raider = *It;
+					if (Raider)
+					{
+						Raider->SetSelected(false);
+					}
+				}
+
+				if (ClickedRaider)
+				{
+					ClickedRaider->SetSelected(true);
+					SelectedRaider = ClickedRaider;
+					UE_LOG(LogTemp, Log, TEXT("Selected RaiderCharacter: %s"), *SelectedRaider->GetName());
+					if (RaiderCommandsWidgetInstance)
+					{
+						RaiderCommandsWidgetInstance->SetVisibility(ESlateVisibility::Visible);
+					}
+				}
+				else
+				{
+					SelectedRaider = nullptr; // Clicked on something else, so deselect
+					UE_LOG(LogTemp, Log, TEXT("Clicked on Actor: %s (Not a RaiderCharacter). Current selection cleared."), *HitActor->GetName());
+					if (RaiderCommandsWidgetInstance)
+					{
+						RaiderCommandsWidgetInstance->SetVisibility(ESlateVisibility::Hidden);
+					}
+				}
+			}
+			else // Hit something, but it's not an actor (e.g. landscape)
+			{
+				// Deselect all raiders if we click on non-actor
+				for (TActorIterator<ARaiderCharacter> It(GetWorld()); It; ++It)
+				{
+					ARaiderCharacter* Raider = *It;
+					if (Raider)
+					{
+						Raider->SetSelected(false);
+					}
+				}
+				SelectedRaider = nullptr;
+				UE_LOG(LogTemp, Log, TEXT("Mouse click hit something, but not an actor. Current selection cleared."));
+				if (RaiderCommandsWidgetInstance)
+				{
+					RaiderCommandsWidgetInstance->SetVisibility(ESlateVisibility::Hidden);
+				}
+			}
+		}
+		else // Clicked on empty space
+		{
+			// Deselect all raiders if we click on empty space
+			for (TActorIterator<ARaiderCharacter> It(GetWorld()); It; ++It)
+			{
+				ARaiderCharacter* Raider = *It;
+				if (Raider)
+				{
+					Raider->SetSelected(false);
+				}
+			}
+			SelectedRaider = nullptr;
+			UE_LOG(LogTemp, Log, TEXT("Mouse click did not hit any actor. Current selection cleared."));
+			if (RaiderCommandsWidgetInstance)
+			{
+				RaiderCommandsWidgetInstance->SetVisibility(ESlateVisibility::Hidden);
+			}
+		}
+	}
+	else
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Failed to deproject mouse position to world."));
+	}
+}

--- a/Source/RaidingGuildManager/Private/RaidViewCameraActor.cpp
+++ b/Source/RaidingGuildManager/Private/RaidViewCameraActor.cpp
@@ -1,0 +1,42 @@
+#include "RaidViewCameraActor.h"
+#include "Camera/CameraComponent.h"
+
+// Sets default values
+ARaidViewCameraActor::ARaidViewCameraActor()
+{
+	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
+	// PrimaryActorTick.bCanEverTick = true; // Not needed for a static camera
+
+	CameraComponent = CreateDefaultSubobject<UCameraComponent>(TEXT("RaidViewCamera"));
+	RootComponent = CameraComponent; // Make the camera component the root
+
+	// Set camera position and rotation for an isometric/top-down view
+	// Looking towards positive X, from a height (Z) and slightly offset in Y or X if desired.
+	// This example sets it up at a distance, looking down at a 60-degree angle.
+	CameraComponent->SetRelativeLocation(FVector(-800.f, 0.f, 1200.f)); // Adjust X, Y, Z for desired distance and height
+	CameraComponent->SetRelativeRotation(FRotator(-60.f, 0.f, 0.f));   // Pitch down, no roll or yaw initially
+
+	// Other useful camera settings you might consider:
+	// CameraComponent->ProjectionMode = ECameraProjectionMode::Orthographic;
+	// CameraComponent->OrthoWidth = 2048.f; // Adjust for desired orthographic view width
+	// CameraComponent->bConstrainAspectRatio = true;
+	// CameraComponent->FieldOfView = 90.f; // For perspective
+}
+
+// Called when the game starts or when spawned
+/*
+void ARaidViewCameraActor::BeginPlay()
+{
+	Super::BeginPlay();
+
+}
+*/
+
+// Called every frame
+/*
+void ARaidViewCameraActor::Tick(float DeltaTime)
+{
+	Super::Tick(DeltaTime);
+
+}
+*/

--- a/Source/RaidingGuildManager/Private/UI/RaiderCommandsWidget.cpp
+++ b/Source/RaidingGuildManager/Private/UI/RaiderCommandsWidget.cpp
@@ -1,0 +1,71 @@
+#include "UI/RaiderCommandsWidget.h"
+#include "Components/Button.h"
+#include "Kismet/GameplayStatics.h" // For GetPlayerController
+#include "RGMPlayerController.h"   // For ARGMPlayerController
+#include "Characters/RaiderCharacter.h" // For ARaiderCharacter and ETemporaryDirective
+#include "Characters/CharacterTypes.h"  // For ETemporaryDirective enum
+
+void URaiderCommandsWidget::NativeConstruct()
+{
+	Super::NativeConstruct();
+
+	if (TauntButton)
+	{
+		TauntButton->OnClicked.AddDynamic(this, &URaiderCommandsWidget::OnTauntButtonClicked);
+	}
+	else
+	{
+		UE_LOG(LogTemp, Error, TEXT("URaiderCommandsWidget: TauntButton is not bound in UMG or is null!"));
+	}
+
+	if (AttackButton)
+	{
+		AttackButton->OnClicked.AddDynamic(this, &URaiderCommandsWidget::OnAttackButtonClicked);
+	}
+	else
+	{
+		UE_LOG(LogTemp, Error, TEXT("URaiderCommandsWidget: AttackButton is not bound in UMG or is null!"));
+	}
+}
+
+void URaiderCommandsWidget::OnTauntButtonClicked()
+{
+	APlayerController* PC = GetOwningPlayer(); // In UserWidget, GetOwningPlayer() is preferred
+	if (!PC)
+	{
+		UE_LOG(LogTemp, Error, TEXT("URaiderCommandsWidget: Could not get Owning Player Controller for Taunt."));
+		return;
+	}
+
+	ARGMPlayerController* RGM_PC = Cast<ARGMPlayerController>(PC);
+	if (RGM_PC && RGM_PC->SelectedRaider)
+	{
+		RGM_PC->SelectedRaider->InjectDirective(ETemporaryDirective::Taunt);
+		UE_LOG(LogTemp, Log, TEXT("Taunt button clicked, directive sent to %s"), *RGM_PC->SelectedRaider->GetName());
+	}
+	else
+	{
+		UE_LOG(LogTemp, Warning, TEXT("URaiderCommandsWidget: RGMPlayerController or SelectedRaider is null for Taunt."));
+	}
+}
+
+void URaiderCommandsWidget::OnAttackButtonClicked()
+{
+	APlayerController* PC = GetOwningPlayer();
+	if (!PC)
+	{
+		UE_LOG(LogTemp, Error, TEXT("URaiderCommandsWidget: Could not get Owning Player Controller for Attack."));
+		return;
+	}
+
+	ARGMPlayerController* RGM_PC = Cast<ARGMPlayerController>(PC);
+	if (RGM_PC && RGM_PC->SelectedRaider)
+	{
+		RGM_PC->SelectedRaider->InjectDirective(ETemporaryDirective::Attack);
+		UE_LOG(LogTemp, Log, TEXT("Attack button clicked, directive sent to %s"), *RGM_PC->SelectedRaider->GetName());
+	}
+	else
+	{
+		UE_LOG(LogTemp, Warning, TEXT("URaiderCommandsWidget: RGMPlayerController or SelectedRaider is null for Attack."));
+	}
+}

--- a/Source/RaidingGuildManager/Public/Characters/CharacterTypes.h
+++ b/Source/RaidingGuildManager/Public/Characters/CharacterTypes.h
@@ -12,3 +12,12 @@ enum class ECharacterClass : uint8
     Tank        UMETA(DisplayName = "Tank"),
     Healer      UMETA(DisplayName = "Healer")
 };
+
+UENUM(BlueprintType)
+enum class ETemporaryDirective : uint8
+{
+	None		UMETA(DisplayName = "None"),
+	Taunt		UMETA(DisplayName = "Taunt"),
+	Attack		UMETA(DisplayName = "Attack")
+	// Add more directives as needed, e.g., MoveTo, DefendTarget
+};

--- a/Source/RaidingGuildManager/Public/Characters/RaiderCharacter.h
+++ b/Source/RaidingGuildManager/Public/Characters/RaiderCharacter.h
@@ -4,9 +4,9 @@
 
 #include "CoreMinimal.h"
 #include "Characters/RGMCharacterBase.h"
-#include "AI/UtilityAI/UtilityAIComponent.h" // Added for UtilityAIComponent
+#include "Characters/CharacterTypes.h" // Added for ETemporaryDirective
 #include "RaiderCharacter.generated.h"
-#include "Characters/CharacterTypes.h"
+// #include "AI/UtilityAI/UtilityAIComponent.h" // No longer needed here, already in RGMCharacterBase or RaiderCharacter.cpp if specific
 #include "Characters/PersonalityStats.h"
 
 class ARaiderAIController; // Forward declaration
@@ -32,10 +32,35 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Personality Stats")
 	FPersonalityStats PersonalityStats;
 
+	// Selection state
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Selection")
+	bool bIsSelected;
+
 protected:
+	// Materials for selection visual feedback
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Selection")
+	UMaterialInterface* OriginalMaterial;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Selection")
+	UMaterialInterface* SelectedMaterial;
+
 	// Overrides from RGMCharacterBase
 	// virtual void InitializeAttributes() override;
 	// virtual void GiveDefaultAbilities() override;
 
+	virtual void BeginPlay() override; // Added BeginPlay for initializing material
 	virtual void Tick(float DeltaTime) override;
+
+public:
+	// Method to set selection state, might be useful for external control too
+	void SetSelected(bool bNewSelectedState);
+
+	// Injects a temporary directive into the AI
+	UFUNCTION(BlueprintCallable, Category = "AI")
+	void InjectDirective(ETemporaryDirective NewDirective);
+
+private:
+	FTimerHandle ClearDirectiveTimerHandle;
+	ETemporaryDirective CurrentDirective;
+	void ClearDirective();
 };

--- a/Source/RaidingGuildManager/Public/RGMPlayerController.h
+++ b/Source/RaidingGuildManager/Public/RGMPlayerController.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/PlayerController.h"
+#include "RGMPlayerController.generated.h"
+
+// Forward declare ARaiderCharacter to avoid circular dependency if not strictly needed in header
+// If we need to operate on ARaiderCharacter members here, include its header.
+// For now, a forward declaration for the pointer type is fine.
+class ARaiderCharacter;
+class URaiderCommandsWidget; // Forward declare the widget class
+class ARaidViewCameraActor; // Forward declare the camera actor
+template<class T> class TSubclassOf; // Forward declare TSubclassOf
+
+UCLASS()
+class RAIDINGGUILDMANAGER_API ARGMPlayerController : public APlayerController
+{
+	GENERATED_BODY()
+
+public:
+	ARGMPlayerController();
+
+protected:
+	virtual void BeginPlay() override; // Added BeginPlay for widget creation
+	virtual void SetupInputComponent() override;
+	void OnLeftMouseClick();
+
+private:
+	// Currently selected raider
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Category = "Selection", meta = (AllowPrivateAccess = "true"))
+	ARaiderCharacter* SelectedRaider;
+
+	// Raider Commands Widget
+	UPROPERTY(EditDefaultsOnly, Category = "UI")
+	TSubclassOf<URaiderCommandsWidget> RaiderCommandsWidgetClass;
+
+	UPROPERTY()
+	URaiderCommandsWidget* RaiderCommandsWidgetInstance;
+};

--- a/Source/RaidingGuildManager/Public/RaidViewCameraActor.h
+++ b/Source/RaidingGuildManager/Public/RaidViewCameraActor.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "GameFramework/Actor.h"
+#include "RaidViewCameraActor.generated.h"
+
+class UCameraComponent;
+
+UCLASS()
+class RAIDINGGUILDMANAGER_API ARaidViewCameraActor : public AActor
+{
+	GENERATED_BODY()
+
+public:
+	// Sets default values for this actor's properties
+	ARaidViewCameraActor();
+
+protected:
+	// Called when the game starts or when spawned
+	// virtual void BeginPlay() override;
+
+public:
+	// Called every frame
+	// virtual void Tick(float DeltaTime) override;
+
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly, Category = "Camera")
+	UCameraComponent* CameraComponent;
+};

--- a/Source/RaidingGuildManager/Public/UI/RaiderCommandsWidget.h
+++ b/Source/RaidingGuildManager/Public/UI/RaiderCommandsWidget.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Blueprint/UserWidget.h"
+#include "RaiderCommandsWidget.generated.h"
+
+class UButton; // Forward declaration
+
+/**
+ * C++ base class for the WBP_RaiderCommands UMG Widget.
+ * This widget will display contextual commands for a selected raider.
+ */
+UCLASS()
+class RAIDINGGUILDMANAGER_API URaiderCommandsWidget : public UUserWidget
+{
+	GENERATED_BODY()
+
+public:
+	// Called when the widget is constructed.
+	// virtual void NativeConstruct() override; // Useful for initial setup if needed
+
+	// These buttons are intended to be bound to UMG Button widgets created in the
+	// WBP_RaiderCommands Blueprint, which should have this class as its parent.
+	// The names of the UMG buttons must match these variable names exactly.
+
+	UPROPERTY(meta = (BindWidget))
+	UButton* TauntButton;
+
+	UPROPERTY(meta = (BindWidget))
+	UButton* AttackButton;
+
+protected:
+	virtual void NativeConstruct() override; // Standard UMG initialization function
+
+	UFUNCTION()
+	void OnTauntButtonClicked();
+
+	UFUNCTION()
+	void OnAttackButtonClicked();
+};


### PR DESCRIPTION
I've implemented the C++ framework for a prototype GUI to simulate voice commands for AI raiders.

Key changes include:

- Player Controller (`ARGMPlayerController`):
    - Added to handle mouse clicks for selecting `ARaiderCharacter` instances.
    - Manages the display of a contextual command UMG widget.
    - Spawns and sets a custom `ARaidViewCameraActor` for a basic isometric view.

- Raider Character (`ARaiderCharacter`):
    - Added `bIsSelected` property and a `SetSelected` method for selection management.
    - Implemented a basic material-swapping visual feedback for selection (requires `SelectedMaterial` to be set, defaults to a placeholder).
    - Added `InjectDirective(ETemporaryDirective)` function to allow external commands to influence AI. This currently logs the intended action and sets a timer to clear the directive, awaiting `UtilityAIComponent` enhancements for actual AI behavior modification.
    - Added `ETemporaryDirective` enum (None, Taunt, Attack) in `CharacterTypes.h`.

- UI Widget (`URaiderCommandsWidget`):
    - C++ base class for a UMG widget (`WBP_RaiderCommands`) intended to display command buttons.
    - Declares `TauntButton` and `AttackButton` (to be bound in UMG).
    - Implements `NativeConstruct` to bind button click handlers.
    - Click handlers call `InjectDirective` on the selected raider via the player controller.

- Camera (`ARaidViewCameraActor`):
    - New actor with a `UCameraComponent` configured for a fixed isometric view.

- Input (`DefaultInput.ini`):
    - Added "LeftMouseClick" action mapping.

**Note:** These changes have NOT been compiled or tested due to persistent issues with the Unreal Engine build tool paths in the development environment. You will need to manually create UMG assets (`WBP_RaiderCommands`) and potentially Blueprint character classes (e.g., for `ATankRaider`) in the Unreal Editor. The AI interaction parts in `ARaiderCharacter` and `UUtilityAIComponent` are placeholders and will need further development for full functionality.